### PR TITLE
Rename data variable `state` to avoid collisions

### DIFF
--- a/spoiler.js
+++ b/spoiler.js
@@ -12,7 +12,7 @@
 
     $(this).each(function() {
       var $spoiler = $(this)
-      $spoiler.data('state', 'shrouded')
+      $spoiler.data('spoiler-state', 'shrouded')
 
       var animationTimer = null
       var step = 0
@@ -43,7 +43,7 @@
 
       var reveal = function() {
         cancelTimer()
-        var finalStep = $spoiler.data('state') == 'shrouded' ? (maxBlur - partialBlur) : maxBlur
+        var finalStep = $spoiler.data('spoiler-state') == 'shrouded' ? (maxBlur - partialBlur) : maxBlur
         if (step < finalStep) {
           step++
           applyBlur()
@@ -62,14 +62,14 @@
       applyBlur()
 
       $(this).on('mouseover', function(e) {
-        if ($spoiler.data('state') == 'shrouded') reveal()
+        if ($spoiler.data('spoiler-state') == 'shrouded') reveal()
       })
       $(this).on('mouseout', function(e) {
-        if ($spoiler.data('state') == 'shrouded') shroud()
+        if ($spoiler.data('spoiler-state') == 'shrouded') shroud()
       })
       $(this).on('click', function(e) {
-        $spoiler.data('state', $spoiler.data('state') == 'shrouded' ? 'revealed' : 'shrouded')
-        $spoiler.data('state') == 'shrouded' ? shroud() : reveal()
+        $spoiler.data('spoiler-state', $spoiler.data('spoiler-state') == 'shrouded' ? 'revealed' : 'shrouded')
+        $spoiler.data('spoiler-state') == 'shrouded' ? shroud() : reveal()
       })
     })
 


### PR DESCRIPTION
Rename `$spoiler.data('state')` to `$spoiler.data('spoiler-state')` on the off chance that another jQuery plugin is using the variable `state`. For instance, maybe a plugin would allow spoilers to be dragged around the page, and store whether the spoiler has been moved yet in `state`. It’s unlikely, but there’s little harm in being careful.

I chose the name `spoiler-state`, but `shrouded-state` or `hidden-state` might also work.
