### PR TITLE
Remove the alert in IE

### DIFF
--- a/spoiler.js
+++ b/spoiler.js
@@ -12,17 +12,12 @@
     hintText: 'Click to reveal completely'
   }
 
-  var alertShown = false
-
   $.fn.spoilerAlert = function(opts) {
     opts = $.extend(defaults, opts || {})
     var maxBlur = opts.max
     var partialBlur = opts.partial
     var hintText = opts.hintText
-    if (!alertShown && browser.msie) {
-      alert("WARNING, this site contains spoilers!")
-      alertShown = true
-    }
+    
     return this.each(function() {
       var $spoiler = $(this)
       $spoiler.data('spoiler-state', 'shrouded')


### PR DESCRIPTION
Not sure if it was a debugging leftover, but I see no point in annoying IE users.